### PR TITLE
Add a method to debug the current selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,24 @@ The argument to `setup` is the path to the python installation which contains th
 
 - Call `:lua require('dap').continue()` to start debugging.
 - See `:help dap-mappings` and `:help dap-api`.
-- Use `:lua require('dap-python').test_method` to debug the closest method above the cursor.
+- Use `:lua require('dap-python').test_method()` to debug the closest method above the cursor.
 
-Currently this only works with the `unittest` test framework. `pytest` and others are not supported yet.
+Supported test frameworks are `unittest` and `pytest`. It defaults to using
+`unittest`. To configure `pytest` set the test runner like this:
+
+
+```vimL
+lua require('dap-python').test_runner = 'pytest'
+```
+
+
+## Mappings
+
+
+```vimL
+nnoremap <silent> <leader>dn :lua require('dap-python').test_method()<CR>
+vnoremap <silent> <leader>ds <ESC>:lua require('dap-python').debug_selection()<CR>
+```
 
 
 ## Work in progress

--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -178,4 +178,39 @@ function M.test_method(opts)
 end
 
 
+--- Strips extra whitespace at the start of the lines
+--
+-- >>> remove_indent({'    print(10)', '    if True:', '        print(20)'})
+-- {'print(10)', 'if True:', '    print(20)'}
+local function remove_indent(lines)
+  local offset = nil
+  for _, line in ipairs(lines) do
+    local first_non_ws = line:find('[^%s]')
+    if first_non_ws > 1 and (not offset or first_non_ws < offset) then
+      offset = first_non_ws
+    end
+  end
+  if offset then
+    return vim.tbl_map(function(x) return string.sub(x, offset) end, lines)
+  else
+    return lines
+  end
+end
+
+
+--- Debug the selected code
+function M.debug_selection(opts)
+  opts = default_test_opts
+  local start_row, start_col = unpack(api.nvim_buf_get_mark(0, '<'))
+  local end_row, end_col = unpack(api.nvim_buf_get_mark(0, '>'))
+  local lines = api.nvim_buf_get_lines(0, start_row - 1, end_row, false)
+  load_dap().run({
+    type = 'python',
+    request = 'launch',
+    code = table.concat(remove_indent(lines), '\n'),
+    console = opts.console
+  })
+end
+
+
 return M


### PR DESCRIPTION
This might require some extensions in nvim-dap as the source is set to
`<string>`. So currently if an exception raises and triggers a stopped
event it will fail because the cursor will be outside of the window.