### PR TITLE
Fix bug in remove_indent (would not work for empty lines)

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -185,7 +185,7 @@ end
 local function remove_indent(lines)
   local offset = nil
   for _, line in ipairs(lines) do
-    local first_non_ws = line:find('[^%s]')
+    local first_non_ws = line:find('[^%s]') or 0
     if first_non_ws > 1 and (not offset or first_non_ws < offset) then
       offset = first_non_ws
     end
@@ -201,8 +201,8 @@ end
 --- Debug the selected code
 function M.debug_selection(opts)
   opts = default_test_opts
-  local start_row, start_col = unpack(api.nvim_buf_get_mark(0, '<'))
-  local end_row, end_col = unpack(api.nvim_buf_get_mark(0, '>'))
+  local start_row, _ = unpack(api.nvim_buf_get_mark(0, '<'))
+  local end_row, _ = unpack(api.nvim_buf_get_mark(0, '>'))
   local lines = api.nvim_buf_get_lines(0, start_row - 1, end_row, false)
   load_dap().run({
     type = 'python',


### PR DESCRIPTION
There may not be a non_ws in every line (if a line contains no characters). Error: comparing nil with a number.