### PR TITLE
Auto Launch Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ There are two default configurations for launching the debugger, `Launch file` a
 If you want to automatically select one of the two modes, you can set the following variable:
 
 ```vimL
-    -- list both configs (default)
+    " list both configs (default)
     vim.g.dap_custom_config = false
-    -- immediately call 'launch' config
+    " immediately call 'launch' config
     vim.g.dap_custom_config = 'launch'
-    -- immediately call 'attach' config
+    " immediately call 'attach' config
     vim.g.dap_custom_config = 'attach'
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Supported test frameworks are `unittest` and `pytest`. It defaults to using
 lua require('dap-python').test_runner = 'pytest'
 ```
 
-
 ## Mappings
 
 
@@ -57,6 +56,19 @@ nnoremap <silent> <leader>dn :lua require('dap-python').test_method()<CR>
 vnoremap <silent> <leader>ds <ESC>:lua require('dap-python').debug_selection()<CR>
 ```
 
+## Auto-Launch Configuration
+
+There are two default configurations for launching the debugger, `Launch file` and `Attach remote`.
+If you want to automatically select one of the two modes, you can set the following variable:
+
+```vimL
+    -- list both configs (default)
+    vim.g.dap_custom_config = false
+    -- immediately call 'launch' config
+    vim.g.dap_custom_config = 'launch'
+    -- immediately call 'attach' config
+    vim.g.dap_custom_config = 'attach'
+```
 
 ## Work in progress
 

--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -64,28 +64,33 @@ function M.setup(adapter_python_path, opts)
 
   if opts.include_configs then
     dap.configurations.python = dap.configurations.python or {}
-    table.insert(dap.configurations.python, {
-      type = 'python';
-      request = 'launch';
-      name = 'Launch file';
-      program = '${file}';
-      console = opts.console;
-    })
-    table.insert(dap.configurations.python, {
-      type = 'python';
-      request = 'attach';
-      name = 'Attach remote';
-      host = function()
-        local value = vim.fn.input('Host [127.0.0.1]: ')
-        if value ~= "" then
-          return value
-        end
-        return '127.0.0.1'
-      end;
-      port = function()
-        return tonumber(vim.fn.input('Port [5678]: ')) or 5678
-      end;
-    })
+    local config_type = vim.g.dap_custom_config
+    if not config_type or config_type == 'launch' then
+      table.insert(dap.configurations.python, {
+        type = 'python';
+        request = 'launch';
+        name = 'Launch file';
+        program = '${file}';
+        console = opts.console;
+      })
+    end
+    if not config_type or config_type == 'attach' then
+      table.insert(dap.configurations.python, {
+        type = 'python';
+        request = 'attach';
+        name = 'Attach remote';
+        host = function()
+          local value = vim.fn.input('Host [127.0.0.1]: ')
+          if value ~= "" then
+            return value
+          end
+          return '127.0.0.1'
+        end;
+        port = function()
+          return tonumber(vim.fn.input('Port [5678]: ')) or 5678
+        end;
+      })
+    end
   end
 end
 

--- a/plugin/dap-python.vim
+++ b/plugin/dap-python.vim
@@ -1,0 +1,3 @@
+if !exists("g:dap_custom_config")
+    let g:dap_custom_config = 0
+endif


### PR DESCRIPTION
I find myself only using the `launch file` config, this simply adds the option to immediately launch that instead of having to go through the second pane and entering `1 -> Enter`. New to vim + lua, so not sure if I just missed a configuration somewhere that already makes this possible (if so, feel free to let me know how and I'll close this!)

Kudos for both nvim-dap and nvim-dap-python!



<img width="638" alt="image" src="https://user-images.githubusercontent.com/5175809/106376598-ca243680-634b-11eb-802f-9c03cf39d9b8.png">
