### PR TITLE
Support test_class and handle class/function structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,9 @@ lua require('dap-python').test_runner = 'pytest'
 
 ```vimL
 nnoremap <silent> <leader>dn :lua require('dap-python').test_method()<CR>
+nnoremap <silent> <leader>df :lua require('dap-python').test_class()<CR>
 vnoremap <silent> <leader>ds <ESC>:lua require('dap-python').debug_selection()<CR>
 ```
-
-
-## Work in progress
-
-
-- Use `:lua require('dap-python').test_class` to debug the closest class above the cursor.
 
 
 ## Looking for Maintainers


### PR DESCRIPTION
Implements `test_class` and improves `test_method` to recognize that in
a construct as follows, `test_b` is not part of `class A`:

    class A:

        def test_a():
            pass

    def test_b():
        pass