### PR TITLE
Remove `print('Running')` and add name to config

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -181,8 +181,8 @@ local function trigger_test(classname, methodname, opts)
     print('Test runner `' .. test_runner .. '` not supported')
     return
   end
-  print('Running', test_path)
   load_dap().run({
+    name = table.concat(prune_nil({classname, methodname}), '.'),
     type = 'python',
     request = 'launch',
     module = test_runner,


### PR DESCRIPTION
Relates to

- https://github.com/mfussenegger/nvim-dap/issues/150
- https://github.com/mfussenegger/nvim-dap/commit/8b7e087af4e4772db84e47441492bd99a05c8664