### PR TITLE
fix for venv python executable paths on Windows

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -5,9 +5,17 @@ local M = {}
 M.test_runner = 'unittest'
 
 
+local is_windows = function()
+    return vim.loop.os_uname().sysname:find("Windows", 1, true) and true
+end
+
+
 local get_python_path = function()
   local venv_path = os.getenv('VIRTUAL_ENV')
   if venv_path then
+    if is_windows() then
+        return venv_path .. '\\Scripts\\python.exe'
+    end
     return venv_path .. '/bin/python'
   end
   return nil


### PR DESCRIPTION
Only thing I'm not sure about is if [this line](https://github.com/mfussenegger/nvim-dap-python/blob/2e87b354a607a26f6706d04353e01c834ff36ee9/lua/dap-python.lua#L172) needs to be changed also. I'm not using unittest, and I'm not really sure exactly what's happening there, anyway...