### PR TITLE
Fix for path mappings in remote attach configs

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -93,6 +93,14 @@ function M.setup(adapter_python_path, opts)
       port = function()
         return tonumber(vim.fn.input('Port [5678]: ')) or 5678
       end;
+      -- These path mappings will work for projects in which the relative path to the
+      -- source code in the local project directory is the same as the absolute path to
+      -- the source code in the container; e.g. local path is {cwd}/app/main.py and the
+      -- remote path (in the container) is /app/main.py
+      pathMappings = {{
+        localRoot = vim.fn.getcwd();
+        remoteRoot = "/";
+      }};
     })
   end
 end


### PR DESCRIPTION
Not sure if this is universal, but this is what I had to do to get remote debugging inside a container working. This was running neovim and docker from inside wsl. Could you maybe try the same from an actual linux host and see if you have the same problems? I can provide example docker-compose and dockerfiles if necessary. 

> These path mappings will work for projects in which the relative path to the
> source code in the local project directory is the same as the absolute path to
> the source code in the container; e.g. local path is {cwd}/app/main.py and the
> remote path (in the container) is /app/main.py