### PR TITLE
Set `program` to absolute path by default

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -76,7 +76,7 @@ function M.setup(adapter_python_path, opts)
       type = 'python';
       request = 'launch';
       name = 'Launch file';
-      program = '${file}';
+      program = '${workspaceFolder}/${file}';
       console = opts.console;
     })
     table.insert(dap.configurations.python, {


### PR DESCRIPTION
So far you could only use the `Launch file` option if the current
working directory was on the same level as the file.

Changing the `program` path to absolute allows to debug files if you're
in the parent directy. E.g. if the source is in `src/main.py`.
