### PR TITLE
Fix multiple levels of subdirs in unittest runner

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -177,7 +177,7 @@ local function trigger_test(classname, methodname, opts)
   local test_path
   local args
   if test_runner == 'unittest' then
-    local path = vim.fn.expand('%:r:s?/?.?')
+    local path = vim.fn.expand('%:r:gs?/?.?')
     test_path = table.concat(prune_nil({path, classname, methodname}), '.')
     args = {'-v', test_path}
   elseif test_runner == 'pytest' then


### PR DESCRIPTION
When a test file lives in the second level of directories or deeper (e.g. `tests/test_group/test_file.py`), the unittest test runner was not transforming the path correctly to a python module (the example would result in `tests.test_group/test_file`).