### PR TITLE
fix(enrich-config): check python arg

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -23,7 +23,7 @@ end
 
 
 local enrich_config = function(config, on_config)
-  if not config.pythonPath then
+  if not config.pythonPath and not config.python then
     config.pythonPath = get_python_path()
   end
   on_config(config)


### PR DESCRIPTION
Debugpy does not allow both settings at once so just added a check before adding `pythonPath`