### PR TITLE
Allow users to define their own test runners & add django runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,31 @@ The argument to `setup` is the path to the python installation which contains th
 - See `:help dap-mappings` and `:help dap-api`.
 - Use `:lua require('dap-python').test_method()` to debug the closest method above the cursor.
 
-Supported test frameworks are `unittest` and `pytest`. It defaults to using
-`unittest`. To configure `pytest` set the test runner like this:
+Supported test frameworks are `unittest`, `pytest` and `django`. It defaults to using
+`unittest`.
+
+To configure a different runner, change the `test_runner` variable. For example
+to configure `pytest` set the test runner like this in `vimL`:
 
 
 ```vimL
 lua require('dap-python').test_runner = 'pytest'
+```
+
+You can also add custom runners. An example in `Lua`:
+
+```lua
+local test_runners = require('dap-python').test_runners
+
+-- `test_runners` is a table. The keys are the runner names like `unittest` or `pytest`.
+-- The value is a function that takes three arguments:
+-- The classname, a methodname and the opts
+-- (The `opts` are coming passed through from either `test_method` or `test_class`)
+-- The function must return a module name and the arguments passed to the module as list.
+test_runners.your_runner = function(classname, methodname, opts)
+  local args = {classname, methodname}
+  return 'modulename', args
+end
 ```
 
 

--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -51,6 +51,7 @@ local function load_dap()
   return dap
 end
 
+
 function M.test_runners.unittest(classname, methodname)
   local path = vim.fn.expand('%:r:gs?/?.?')
   local test_path = table.concat(prune_nil({path, classname, methodname}), '.')
@@ -65,6 +66,14 @@ function M.test_runners.pytest(classname, methodname)
   -- -s "allow output to stdout of test"
   local args = {'-s', test_path}
   return 'pytest', args
+end
+
+
+function M.test_runners.django(classname, methodname)
+  local path = vim.fn.expand('%:r:gs?/?.?')
+  local test_path = table.concat(prune_nil({path, classname, methodname}), '.')
+  local args = {'test', test_path}
+  return 'django', args
 end
 
 


### PR DESCRIPTION
To automatically detect the right runner users can do something like this:


```lua
local function mkopts()
  if vim.loop.fs_stat('manage.py') then
    return { test_runner = 'django' }
  else
    return { test_runner = 'unittest' }
  end
end

local function test_method()
  return dappy.test_method(mkopts())
end

local function test_class()
  return dappy.test_class(mkopts())
end


local silent = { silent = true }
vim.keymap.set('n', '<leader>dn', test_method, silent)
vim.keymap.set('n', '<leader>df', test_class, silent)
```

(Might add something like this built-in if there's enough interest)