### PR TITLE
fix: trim path to Python installation

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -80,7 +80,7 @@ end
 --- Register the python debug adapter
 function M.setup(adapter_python_path, opts)
   local dap = load_dap()
-  adapter_python_path = vim.fn.expand(adapter_python_path)
+  adapter_python_path = vim.fn.expand(vim.fn.trim(adapter_python_path))
   opts = vim.tbl_extend('keep', opts or {}, default_setup_opts)
   dap.adapters.python = function(cb, config)
     if config.request == 'attach' then


### PR DESCRIPTION
Just a small quality-of-life improvement. Without the change, if a user
calls `setup` like this

    require('dap-python').setup(vim.fn.system('which python3'))

an error is thrown because the `system` call returns a value with a
trailing newline.