### PR TITLE
Allow SetupOpts to be nil in @param documentation

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -95,7 +95,7 @@ end
 
 --- Register the python debug adapter
 ---@param adapter_python_path string|nil Path to the python interpreter. Path must be absolute or in $PATH and needs to have the debugpy package installed. Default is `python3`
----@param opts SetupOpts See |SetupOpts|
+---@param opts SetupOpts|nil See |SetupOpts|
 function M.setup(adapter_python_path, opts)
   local dap = load_dap()
   adapter_python_path = adapter_python_path and vim.fn.expand(vim.fn.trim(adapter_python_path)) or 'python3'


### PR DESCRIPTION
Explicitly allow passing nil to the second parameter of the setup function as shown in the usage examples of this plugin. Otherwise, LSPs might report a missing parameter for this function.