### PR TITLE
fix wrong conda path to executable

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -33,6 +33,9 @@ local get_python_path = function()
     if is_windows() then
         return venv_path .. '\\Scripts\\python.exe'
     end
+    if os.getenv('CONDA_PREFIX') then
+      return venv_path
+    end
     return venv_path .. '/bin/python'
   end
   return nil


### PR DESCRIPTION
At least in my case `return venv_path .. '/bin/python'` causes the path to result in: /Users/<user_name>/miniconda3/envs/<env_name>/bin/python/bin/python.