### PR TITLE
Add support for passing args to runners

### DIFF
--- a/doc/dap-python.txt
+++ b/doc/dap-python.txt
@@ -11,6 +11,16 @@ M.test_runner                                           *dap-python.test_runner*
     Type: ~
         (string)  name of the test runner
 
+M.args                                                 *dap-python.args*
+     Test runner args to use by default. Default is {}. See |dappy.args|
+     Override this to set different runner args:
+     ```
+     require('dap-python').args = {"-v"}
+     ```
+
+    Type: ~
+        (table)  <str1, str2, ..., strN>
+
 
 M.test_runners                                         *dap-python.test_runners*
      Table to register test runners.

--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -11,6 +11,14 @@ local M = {}
 ---@type string name of the test runner
 M.test_runner = 'unittest'
 
+--- Extra args to pass to test runner. Default is "{}". See |dap-python.args|
+--- Override this to set an arg:
+--- ```
+--- require('dap-python').args = {"-v"}
+--- ```
+---@type list of args to pass to the test runner
+M.args = {}
+
 --- Table to register test runners.
 --- Built-in are test runners for unittest, pytest and django.
 --- The key is the test runner name, the value a function to generate the
@@ -252,6 +260,9 @@ local function trigger_test(classname, methodname, opts)
   end
   assert(type(runner) == "function", "Test runner must be a function")
   local module, args = runner(classname, methodname)
+  for _,v in ipairs(M.args) do
+   table.insert(args, v)
+  end
   local config = {
     name = table.concat(prune_nil({classname, methodname}), '.'),
     type = 'python',


### PR DESCRIPTION
This allows users to customize runner commands with a table of args to add to the test runner call.

from my config:
```vimrc
" DAP - debug adapter protocol                                                  
lua require("dap-python").setup("~/.virtualenvs/debugpy/bin/python")            
lua require("dap-python").test_runner = 'pytest'                                
lua require("dap-python").args = {'-v'}        
```

In this example it prints assertion failures more verbosely (tested locally).

(fair warning - I don't know lua, but it works so figured I'd offer a PR)