### PR TITLE
Set `subProcess` to false if not present in config

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -67,6 +67,9 @@ local enrich_config = function(config, on_config)
   if not config.pythonPath and not config.python then
     config.pythonPath = get_python_path()
   end
+  if config.subProcess == nil then
+    config.subProcess = false
+  end
   on_config(config)
 end
 


### PR DESCRIPTION
Until the `startDebugging` request is implemented in both nvim-dap and
debugpy it's safer to set it to false as it can cause issues with some
packages. See https://github.com/microsoft/debugpy/issues/1096
