### PR TITLE
bugfix: issue 91 -> Test runner "unittest" not working on windows

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -100,7 +100,12 @@ end
 
 ---@private
 function M.test_runners.unittest(classname, methodname)
-  local path = vim.fn.expand('%:.:r:gs?/?.?')
+  local path
+  if is_windows() then
+    path = vim.fn.expand('%:.:r:gs?\\?.?')
+  else
+    path = vim.fn.expand('%:.:r:gs?/?.?')
+  end
   local test_path = table.concat(prune_nil({path, classname, methodname}), '.')
   local args = {'-v', test_path}
   return 'unittest', args


### PR DESCRIPTION
Hey,

When running windows, using "unittest", backwards slashes were not transformed to periods, rendering an invalid module path. My proposed solution [here](https://github.com/mfussenegger/nvim-dap-python/issues/91) contained a rather complex regex, so I decided to keep it simple and used the `is_windows` function.

Thanks for maintaining such a nice framework. I use it everyday!

Regards,


Bart