### PR TITLE
feat: increase the priority of resolve_python configuration

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -71,11 +71,6 @@ end
 local check_python_path = function (pypath)
   assert(type(pypath) == "string", "resolve_python must return a string")
 
-  if pypath:sub(1, 1) == "~" then
-    local homeDir = os.getenv("HOME")
-    pypath = homeDir .. pypath:sub(2)
-  end
-
   local f = io.open(pypath, "r")
   if f then
     io.close(f)


### PR DESCRIPTION
nvim-dap-python by default looks for VIRTUAL_ENV and CONDA_PREFIX environment variables, `resolve_python` only take effect in the absence of VIRTUAL_ENV and CONDA_PREFIX even when `resolve_python` is configured which is not intuitive enough.

This pr allows users to prioritize using configurations specified by `resolve_python` and fallback to use the default environment when configuration errors occur.