### PR TITLE
Make is-windows check more reliable

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -43,7 +43,7 @@ local function prune_nil(items)
 end
 
 local is_windows = function()
-    return vim.loop.os_uname().sysname:find("Windows", 1, true) and true
+  return vim.fn.has("win32") == 1
 end
 
 


### PR DESCRIPTION
`sysname` doesn't always contain `Windows`, depending on how Neovim is
run on Windows it can contain stuff like `MINGW32_NT-10.0`

Closes https://github.com/mfussenegger/nvim-dap-python/issues/115
