### PR TITLE
Only use venv, .venv, env or .env if it's a directory

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -102,7 +102,7 @@ local get_python_path = function()
     for _, folder in ipairs({"venv", ".venv", "env", ".env"}) do
       local path = root .. "/" .. folder
       local stat = uv.fs_stat(path)
-      if stat then
+      if stat and stat.type == "directory" then
         return python_exe(path)
       end
     end


### PR DESCRIPTION
Should solve https://github.com/mfussenegger/nvim-dap-python/issues/126

Maybe this is good enough - another option would be to double check the
if the python path exists, but that would add some extra workload.
