### PR TITLE
Fixes `default_runner` returning nil in some circumstances

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -38,6 +38,7 @@ local function default_runner()
       end
       f:close()
     end
+    return 'unittest'
   else
     return 'unittest'
   end


### PR DESCRIPTION
Closes #154 