### PR TITLE
fix:default_runner: Look for marker files within all possible root_dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ can install it manually using either:
    - Use `:lua require('dap-python').test_method()` to debug the closest method above the cursor.
 
    Supported test frameworks are `unittest`, `pytest` and `django`. By default it
-   tries to detect the runner by probing for `pytest.ini` and `manage.py`, if
-   neither are present it defaults to `unittest`.
+   tries to detect the runner by probing for presence of `pytest.ini` or
+   `manage.py`, or for a `tool.pytest` directive inside `pyproject.toml`, if
+   none are present it defaults to `unittest`.
 
    To configure a different runner, change the `test_runner` variable. For
    example, to configure `pytest` set the test runner like this in your

--- a/doc/dap-python.txt
+++ b/doc/dap-python.txt
@@ -3,8 +3,8 @@ Python extension for nvim-dap                                       *dap-python*
 
 M.test_runner                                           *dap-python.test_runner*
      Test runner to use by default.
-     The default value is dynamic and depends on `pytest.ini` or `manage.py` markers.
-     If neither is found "unittest" is used. See |dap-python.test_runners|
+     The default value is dynamic and depends on `pytest.ini`, `manage.py` or `pyproject.toml` markers.
+     If none are found "unittest" is used. See |dap-python.test_runners|
      Override this to set a different runner:
      ```
      require('dap-python').test_runner = "pytest"


### PR DESCRIPTION
Changes `default_runner` to run its same logic over each folder path returned by `root_dirs()`, returning the first success - if none are found, it defaults to `unittest`.

Note: this removes the trailing `return 'unittest'` from within the `elseif uv.fs_stat("pyproject.toml") then ...` scope, and instead proceeds with checking the next root folder in the loop - this is intentional.

Also updates associated docs to note the logic.