### PR TITLE
Fix missing method case handling in test_method

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -451,7 +451,7 @@ end
 function M.test_method(opts)
   opts = vim.tbl_extend('keep', opts or {}, default_test_opts)
   local functions = M._get_nodes(0, "function")
-  if not functions then
+  if not functions or not functions[1] then
     print('No test method found near cursor')
     return
   end


### PR DESCRIPTION
Should print "No test method found near cursor" instead of a stacktrace
if there is no function
