### PR TITLE
README.md: Use python3 in the setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ can install it manually using either:
    Or if installed globally:
 
    ```lua
-   require("dap-python").setup("python")
-   -- If using the above, then `python -m debugpy --version`
+   require("dap-python").setup("python3")
+   -- If using the above, then `python3 -m debugpy --version`
    -- must work in the shell
    ```
 


### PR DESCRIPTION
I wasn't fully aware of how the plugin worked so I assumed that the example in the README would setup python3 for me, as nobody uses python2 anymore (well, at least almost nobody :/).