### PR TITLE
fix: add cwd to dap-python launch configurations

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -245,6 +245,7 @@ function M.setup(adapter_python_path, opts)
       request = 'launch';
       name = 'Launch file';
       program = '${file}';
+      cwd = vim.fn.getcwd();
       console = opts.console;
       pythonPath = opts.pythonPath,
     })
@@ -253,6 +254,7 @@ function M.setup(adapter_python_path, opts)
       request = 'launch';
       name = 'Launch file with arguments';
       program = '${file}';
+      cwd = vim.fn.getcwd();
       args = function()
         local args_string = vim.fn.input('Arguments: ')
         return vim.split(args_string, " +")
@@ -277,6 +279,7 @@ function M.setup(adapter_python_path, opts)
       name = 'Run doctests in file',
       module = 'doctest',
       args = { "${file}" },
+      cwd = vim.fn.getcwd(),
       noDebug = true,
       console = opts.console,
       pythonPath = opts.pythonPath,


### PR DESCRIPTION
The `cwd` field was missing from the launch configurations in `dap-python.lua`, causing issues when launching files from different directories. This commit adds the `cwd` field to all launch configurations, setting it to the current working directory using `vim.fn.getcwd()`. This ensures that the debugger correctly finds the necessary files and dependencies.