### PR TITLE
Mute debugpySockets event warning log messages

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -237,6 +237,11 @@ function M.setup(adapter_python_path, opts)
   end
   dap.adapters.debugpy = dap.adapters.python
 
+  -- nvim-dap logs warnings for unhandled custom events
+  -- Mute it
+  dap.listeners.before["event_debugpySockets"]["dap-python"] = function()
+  end
+
   if opts.include_configs then
     local configs = dap.configurations.python or {}
     dap.configurations.python = configs


### PR DESCRIPTION
Based on https://github.com/microsoft/debugpy/pull/1404 the event is
informative. It shouldn't result in warning logs if the information
isn't used.
