### PR TITLE
Use dap.utils splitstr if available for file:args config

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -265,6 +265,10 @@ function M.setup(python_path, opts)
       program = '${file}';
       args = function()
         local args_string = vim.fn.input('Arguments: ')
+        local utils = require("dap.utils")
+        if utils.splitstr and vim.fn.has("nvim-0.10") == 1 then
+          return utils.splitstr(args_string)
+        end
         return vim.split(args_string, " +")
       end;
       console = opts.console;


### PR DESCRIPTION
It treats quoted strings as one argument
