### PR TITLE
feat: add cwd option to setup opts

### DIFF
--- a/doc/dap-python.txt
+++ b/doc/dap-python.txt
@@ -110,6 +110,7 @@ dap-python.setup.opts                                    *dap-python.setup.opts*
     Fields: ~
         {include_configs?}  (boolean)             Add default configurations
         {console?}          (dap-python.console)
+        {cwd?}              (string|function|nil) Working directory for the debug session.
         {pythonPath?}       (string)
                                                    Path to python interpreter. Uses interpreter from `VIRTUAL_ENV` environment
                                                    variable or `python_path` by default

--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -138,6 +138,7 @@ end
 local default_setup_opts = {
   include_configs = true,
   console = 'integratedTerminal',
+  cwd = nil,
   pythonPath = nil,
 }
 
@@ -276,6 +277,7 @@ function M.setup(python_path, opts)
       name = 'file';
       program = '${file}';
       console = opts.console;
+      cwd = opts.cwd,
       pythonPath = opts.pythonPath,
     })
     table.insert(configs, {
@@ -292,6 +294,7 @@ function M.setup(python_path, opts)
         return vim.split(args_string, " +")
       end;
       console = opts.console;
+      cwd = opts.cwd,
       pythonPath = opts.pythonPath,
     })
     table.insert(configs, {
@@ -313,6 +316,7 @@ function M.setup(python_path, opts)
       args = { "${file}" },
       noDebug = true,
       console = opts.console,
+      cwd = opts.cwd,
       pythonPath = opts.pythonPath,
     })
   end
@@ -576,6 +580,7 @@ end
 ---@class dap-python.setup.opts
 ---@field include_configs? boolean Add default configurations
 ---@field console? dap-python.console
+---@field cwd? string|function|nil Working directory for the debug session. Default is `nil`
 ---
 --- Path to python interpreter. Uses interpreter from `VIRTUAL_ENV` environment
 --- variable or `python_path` by default


### PR DESCRIPTION
This commit introduces a `cwd` option to `dap-python.setup.opts`, enabling users to specify the working directory for debug sessions.

- Useful for projects with complex directory structures.
- Default value is `nil` to preserve existing behavior.

---

## Current Configuration

Here is my current `nvim-dap-python` setup:

```lua
return {
    "mfussenegger/nvim-dap-python",
    dependencies = "mfussenegger/nvim-dap",
    ft = "python",
    config = function()
      require("dap-python").setup()
    end,
}
```

## Issue Faced

Given the following project structure:

```
.
├── examples
│   └── generate_signature.py
└── keys
    ├── private_key.pem
    └── public_key.pem
```

When I open Neovim in the project folder, load `examples/generate_signature.py`, and run the debugger using `require("dap").continue()`, I encounter the following error:

```python
with open("keys/private_key.pem", "r") as file:     ■ Thread stopped due to exception of type FileNotFoundError (unhandled)  Description: [Errno 2] No such file or directory: 'keys/private_key.pem'
```

This happens because `debugpy` defaults the working directory (`cwd`) to the directory containing the file being debugged (`./examples`) rather than the Neovim working directory (`vim.fn.getcwd()`). As a result, relative paths like `keys/private_key.pem` are resolved incorrectly.

## Proposed Solution

To resolve this issue, I propose adding an optional `cwd` parameter to the `dap-python.setup.opts` configuration. This option will allow users to explicitly specify the working directory for debugging sessions. By default, `debugpy` uses the directory of the file being debugged as the working directory, but with this change, users can customize the `cwd` to match Neovim’s current working directory (`vim.fn.getcwd()`), ensuring that relative paths are resolved correctly.

### Changes:
1. **Add a `cwd` option** to the `dap-python.setup.opts` configuration.
2. The `cwd` option can be set to a function that dynamically returns the desired directory. If the option is not set, the default behavior (using the file's directory) will be maintained.

### Updated `nvim-dap-python` configuration:
```lua
return {
    "mfussenegger/nvim-dap-python",
    dependencies = "mfussenegger/nvim-dap",
    ft = "python",
    config = function()
        require("dap-python").setup(nil, {
            cwd = function()
                return vim.fn.getcwd()  -- Set cwd to Neovim's current working directory
            end
        })
    end,
}
```
