### PR TITLE
Pryoritize reslove_python in venv selection

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -92,6 +92,12 @@ end
 
 ---@return string|nil
 local get_python_path = function()
+
+  if M.resolve_python then
+    assert(type(M.resolve_python) == "function", "resolve_python must be a function")
+    return M.resolve_python()
+  end
+
   local venv_path = os.getenv('VIRTUAL_ENV')
   if venv_path then
     return python_exe(venv_path)
@@ -103,11 +109,6 @@ local get_python_path = function()
       return venv_path .. '\\python.exe'
     end
     return venv_path .. '/bin/python'
-  end
-
-  if M.resolve_python then
-    assert(type(M.resolve_python) == "function", "resolve_python must be a function")
-    return M.resolve_python()
   end
 
   for root in roots() do


### PR DESCRIPTION
According to the documentation [here](https://github.com/mfussenegger/nvim-dap-python?tab=readme-ov-file#python-dependencies-and-virtualenv):

> ## Python dependencies and virtualenv
>  
>`nvim-dap-python` by default tries to detect a virtual environment and uses it
>when debugging your application. It looks for:
>  
>- The environment variables `VIRTUAL_ENV` and `CONDA_PREFIX`
>- The folders `venv`, `.venv`, `env`, `.env` relative to either the current
>  working directory or the `root_dir` of a active language server client. See
>  `:h lsp.txt` for more information about the latter.
>   
>If you're using another way to manage virtual environments, you can set a
>custom `resolve_python` function:
>   
>```lua
>require('dap-python').resolve_python = function()
>  return '/absolute/path/to/python'
>end
>```

nvim-dap-python should by default try to automatically find the virtual environment using environment variables, and specific folders, however a user of the plugin can override those settings with `resolve_python`.

However the code is not consistent with this description, and due to the ordering, environment variables override `resolve_python` and `resolve_python` override the venv folders.

I switched the order so that if the user defines `resolve_python` he has full control control on the environment, which I think is the desired behaveour.
