### PR TITLE
Fix first line in doc for local-additions

### DIFF
--- a/doc/dap-python.txt
+++ b/doc/dap-python.txt
@@ -1,5 +1,5 @@
+*dap-python*                                     Python extension for nvim-dap
 ==============================================================================
-Python extension for nvim-dap                                       *dap-python*
 
 M.test_runner                                           *dap-python.test_runner*
      Test runner to use by default.


### PR DESCRIPTION
The documentation for vim help pages states that a first line is required for the file to appear under `:help local-additions`, with the following format: `*tag* description`

This change implements that