### PR TITLE
Improve line parsing for .env files

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -133,8 +133,11 @@ local function parse_envfile(path)
   end
   local env = {}
   for line in f:lines() do
-    local key, value = line:match("([^=]+)=(.+)")
-    env[key] = value
+    local key, value = line:match("^%s*([^#=]+)%s*=%s*(.-)%s*#?%s*.*$")
+    if key then
+      value = value:gsub("^'(.*)'$", "%1"):gsub('^"(.*)"$', "%1")
+      env[key] = value
+    end
   end
   f:close()
   return env


### PR DESCRIPTION
Current line parsing is very crude and fails, for example on empty lines. This PP aims to improve parsing a bit to avoid some edge cases.  Not sure how close to [python](https://github.com/theskumar/python-dotenv?tab=readme-ov-file)-dotenv it is, but still a start.