### PR TITLE
fix: empty env table

### DIFF
--- a/lua/dap-python.lua
+++ b/lua/dap-python.lua
@@ -153,7 +153,7 @@ local enrich_config = function(config, on_config)
   local envfile = vim.fn.fnamemodify(config.envFile or "./.env", ":p")
   config.envFile = nil
   local env = parse_envfile(envfile)
-  if env then
+  if env and next(env) then
     config.env = vim.tbl_deep_extend('force', config.env or {}, env)
   end
   on_config(config)


### PR DESCRIPTION
It can happen that the `envFile` exists but has empty content, when that's the case, `env` gets set to an empty table that is serialized as an empty list (not dict) and rejected by debugpy because it expects a dict.

### DAP Error
```
Error on launch: Invalid message: "env" must be dict
```

### Debugpy trace
```
E+00000.183: /handling #1 request "launch" from Adapter/
             Traceback (most recent call last):
               File "/Users/antoine.bertin/.local/share/nvim/mason/packages/debugpy/venv/lib/python3.11/site-
packages/debugpy/launcher/../../debugpy/common/messaging.py", line 385, in __call__
                 value = validate(value)
                         ^^^^^^^^^^^^^^^
               File "/Users/antoine.bertin/.local/share/nvim/mason/packages/debugpy/venv/lib/python3.11/site-
packages/debugpy/launcher/../../debugpy/common/json.py", line 276, in validate
                 of_type(dict)(value)
               File "/Users/antoine.bertin/.local/share/nvim/mason/packages/debugpy/venv/lib/python3.11/site-
packages/debugpy/launcher/../../debugpy/common/json.py", line 128, in validate
                 raise TypeError("must be " + " or ".join(t.__name__ for t in classinfo))
             TypeError: must be dict
             
             During handling of the above exception, another exception occurred:
             
             Traceback (most recent call last):
               File "/Users/antoine.bertin/.local/share/nvim/mason/packages/debugpy/venv/lib/python3.11/site-
packages/debugpy/launcher/../../debugpy/common/messaging.py", line 1016, in __init__
                 raise self
             debugpy.common.messaging.InvalidMessageError: Invalid message: "env" must be dict

E+00000.185: /handling #1 request "launch" from Adapter/
             Handler 'launch_request' (file '/Users/antoine.bertin/.local/share/nvim/mason/packages/debugpy/ven
v/lib/python3.11/site-packages/debugpy/launcher/../../debugpy/launcher/handlers.py', line 14)
             couldn't handle #1 request "launch" from Adapter:
             Invalid message: "env" must be dict
```

### DAP request
_Notice the empty `env`_
```
[DEBUG] 2025-09-10 13:46:50 dap/session.lua:1855	"request"	{
  arguments = {
    args = { "--results-file", "/var/folders/4s/1nhxc2yx6hlc5hx6vcy0wc900000gp/T/nvim.antoine.bertin/omg2uU/3", "--stream-file", "/var/folders/4s/1nhxc2yx6hlc5hx6vcy0wc900000gp/T/nvim.antoine.bertin/omg2uU/4", "--runner", "pytest", "--", "/Users/antoine.bertin/Projects/xxx/tests/test_something.py::test_the_thing" },
    cwd = "/Users/antoine.bertin/Projects/xxx",
    env = {},
    name = "Neotest Debugger",
    program = "/Users/antoine.bertin/.local/share/nvim/lazy/neotest-python/neotest.py",
    python = { "/Users/antoine.bertin/Projects/xxx/.venv/bin/python" },
    request = "launch",
    type = "python"
  },
  command = "launch",
  seq = 2,
  type = "request"
}
```

I considered fixing this in `nvim-dap` but actually `arguments` is of type `any` so I imagine this is up to plugins such as this one to send valid data in there.

nasty one..